### PR TITLE
Implement button for Well API

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,6 +4,11 @@ export declare class standardfield implements ComponentFramework.StandardControl
      * Empty constructor.
      */
     private _inputElement;
+    private _buttonElement;
+    private _spinnerElement;
+    private _container;
+    private _context;
+    private _notifyOutputChanged;
     constructor();
     /**
      * Used to initialize the control instance. Controls can kick off remote server calls and other initialization actions here.
@@ -24,6 +29,7 @@ export declare class standardfield implements ComponentFramework.StandardControl
      * @returns an object based on nomenclature defined in manifest, expecting object[s] for property marked as "bound" or "output"
      */
     getOutputs(): IOutputs;
+    private onButtonClick;
     /**
      * Called when the control is to be removed from the DOM tree. Controls should use this call for cleanup.
      * i.e. cancelling any pending remote calls, removing listeners, etc.

--- a/standardfield/ControlManifest.Input.xml
+++ b/standardfield/ControlManifest.Input.xml
@@ -18,7 +18,7 @@
       -->
     </external-service-usage>
     <!-- property node identifies a specific, configurable piece of data that the control expects from CDS -->
-    <property name="sampleProperty" display-name-key="Property_Display_Key" description-key="Property_Desc_Key" of-type="SingleLine.Text" usage="bound" required="true" />
+    <property name="rpc_wellapi" display-name-key="Property_Display_Key" description-key="Property_Desc_Key" of-type="SingleLine.Text" usage="bound" required="true" />
     <!--
       Property node's of-type attribute can be of-type-group attribute.
       Example:
@@ -37,17 +37,8 @@
       <resx path="strings/standardfield.1033.resx" version="1.0.0" />
       -->
     </resources>
-    <!-- UNCOMMENT TO ENABLE THE SPECIFIED API
     <feature-usage>
-      <uses-feature name="Device.captureAudio" required="true" />
-      <uses-feature name="Device.captureImage" required="true" />
-      <uses-feature name="Device.captureVideo" required="true" />
-      <uses-feature name="Device.getBarcodeValue" required="true" />
-      <uses-feature name="Device.getCurrentPosition" required="true" />
-      <uses-feature name="Device.pickFile" required="true" />
-      <uses-feature name="Utility" required="true" />
       <uses-feature name="WebAPI" required="true" />
     </feature-usage>
-    -->
   </control>
 </manifest>


### PR DESCRIPTION
## Summary
- add property `rpc_wellapi` and enable WebAPI usage
- implement button with search icon and spinner
- wire up custom action call and output generation

## Testing
- `npm run lint` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685566fc929c832c9edee33c12346388