### PR TITLE
Fix type errors for rpc_wellapi property

### DIFF
--- a/standardfield/generated/ManifestTypes.d.ts
+++ b/standardfield/generated/ManifestTypes.d.ts
@@ -1,0 +1,11 @@
+/*
+*This is auto generated from the ControlManifest.Input.xml file
+*/
+
+// Define IInputs and IOutputs Type. They should match with ControlManifest.
+export interface IInputs {
+    rpc_wellapi: ComponentFramework.PropertyTypes.StringProperty;
+}
+export interface IOutputs {
+    rpc_wellapi?: string;
+}

--- a/standardfield/index.ts
+++ b/standardfield/index.ts
@@ -96,7 +96,7 @@ export class standardfield implements ComponentFramework.StandardControl<IInputs
             })
         };
 
-        this._context.webAPI.execute(request)
+        (this._context.webAPI as any).execute(request)
             .then((response: any) => {
                 if (response.ok) {
                     return response.json();


### PR DESCRIPTION
## Summary
- add typings for `rpc_wellapi` in generated ManifestTypes
- cast `webAPI` to any so execute can be called

## Testing
- `npm run lint` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568943f320832ca83f022cc44c6723