### PR TITLE
Fix npm start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # GetWellData
+
+## Development
+
+1. Install dependencies.
+
+```bash
+npm install
+```
+
+2. Start the control.
+
+```bash
+npm start
+```
+
+The `start` script uses `pcf-scripts` so the dependencies must be installed before running it.

--- a/standardfield/index.ts
+++ b/standardfield/index.ts
@@ -1,4 +1,3 @@
-import { Console } from "console";
 import { IInputs, IOutputs } from "./generated/ManifestTypes";
 
 export class standardfield implements ComponentFramework.StandardControl<IInputs, IOutputs> {


### PR DESCRIPTION
## Summary
- remove unused Console import
- document prerequisite npm install step to avoid missing `pcf-scripts` errors

## Testing
- `npm run lint` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568cf724ec832c907522ce5839b218