### PR TITLE
Fix TypeScript compile errors

### DIFF
--- a/standardfield/componentframework-stubs.d.ts
+++ b/standardfield/componentframework-stubs.d.ts
@@ -1,0 +1,14 @@
+declare namespace ComponentFramework {
+    namespace PropertyTypes {
+        interface StringProperty {}
+    }
+    interface WebApi {}
+    interface Context<T> {
+        parameters: any;
+        webAPI: WebApi;
+    }
+    interface Dictionary {}
+    interface StandardControl<I,O> {
+        init(context: Context<I>, notifyOutputChanged: () => void, state: Dictionary, container: HTMLDivElement): void;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "./dist"
   },
   "include": [
-    "**/*.ts"
+    "**/*.ts",
+    "**/*.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- stub minimal ComponentFramework definitions
- support `.d.ts` files in TypeScript build

## Testing
- `npx tsc`
- `npm run build` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68568e59bf6c832ca95071965c1a2cd9