### PR TITLE
Fix npm install peer dependency conflicts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary
- add `.npmrc` with `legacy-peer-deps=true` so npm install works without ERESOLVE errors

## Testing
- `npm run lint` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685690397e0c832ca85d0a7545785f0c